### PR TITLE
feat(#17): lethal detection BW via directDamage (TB exclu)

### DIFF
--- a/engine-ts/src/characters/black_widow/abilities.ts
+++ b/engine-ts/src/characters/black_widow/abilities.ts
@@ -124,6 +124,27 @@ export function bestAbilityName(dice: number[], upgrades: number, tbOnOpp: numbe
   return cands.reduce((best, cur) => (cur[1] > best[1] ? cur : best))[0]
 }
 
+// Direct HP damage per ability this turn, excluding TB / Agility / CP gain EV.
+// Keys match short names returned by getCandidates / bestAbilityName (what probDist uses).
+// Vengeance rider: dmg-only contribution is 4 × 5/6 (each non-1 face, a "1" inflicts TB instead).
+export function directDamageByName(upgrades: number, _tbOnOpp: number): Record<string, number> {
+  const rrt = upgrades >= RRT_THRESHOLD_UPGRADES ? RRT_ALL_ATTACK_BONUS : 0
+  const hackedThresh = upgrades >= HACKED_THRESHOLD_UPGRADES ? HACKED_THRESHOLD_BONUS : 0
+  const vengeanceRiderDmg = VENGEANCE_RIDER_DICE * (5 / 6)
+  return {
+    'Baton Strike 3B':    BATON_STRIKE_3B + rrt,
+    'Baton Strike 4B':    BATON_STRIKE_4B + rrt,
+    'Baton Strike 5B':    BATON_STRIKE_5B + rrt,
+    'Infiltrate':         INFILTRATE_BASE_DMG + rrt,
+    "Widow's Gauntlets":  GAUNTLETS_BASE_DMG + upgrades + rrt,
+    'Hacked':             HACKED_BASE_DMG + hackedThresh + rrt,
+    'Grapple':            GRAPPLE_BASE_DMG + upgrades + rrt,
+    'Vengeance':          VENGEANCE_BASE_DMG + vengeanceRiderDmg + rrt,
+    "Widow's Bite":       WIDOWS_BITE_BASE_DMG + rrt,
+    'Whiff':              0,
+  }
+}
+
 export function buildAbilityBoard(dice: number[], upgrades: number, tbOnOpp: number): AbilityEntry[] {
   const matched = new Set(getCandidates(dice, upgrades, tbOnOpp).map(([n]) => n))
   const rrt = upgrades >= RRT_THRESHOLD_UPGRADES ? RRT_ALL_ATTACK_BONUS : 0

--- a/engine-ts/src/characters/black_widow/config.ts
+++ b/engine-ts/src/characters/black_widow/config.ts
@@ -1,6 +1,7 @@
 import type { CharacterConfig, AbilityEntry } from '../../core/types.js'
 import {
   bwFaceToSymbol, bestAbilityValue, bestAbilityName, buildAbilityBoard, getCandidates,
+  directDamageByName,
 } from './abilities.js'
 
 export interface BWState {
@@ -28,5 +29,8 @@ export const bwConfig: CharacterConfig<BWState> = {
   },
   stateKey(state) {
     return `${state.upgrades}|${state.tbOnOpp}`
+  },
+  directDamageByName(state) {
+    return directDamageByName(state.upgrades, state.tbOnOpp)
   },
 }

--- a/engine-ts/src/core/evaluator.ts
+++ b/engine-ts/src/core/evaluator.ts
@@ -6,6 +6,10 @@ export interface KeepOption {
   ev: number
   probDist: Record<string, number>
   isGuaranteed?: boolean
+  // Max direct HP damage across outcomes with non-zero probability, excluding TB/Agility/CP
+  // EV. Present only when the config exposes `directDamageByName`. Used by UI for lethal
+  // detection — EV includes non-damage gains so can't be compared directly to enemy HP.
+  directDamage?: number
 }
 
 export interface SolverResult {
@@ -138,16 +142,29 @@ export function calculateOptimalKeep<S>(
 ): SolverResult {
   const sorted = [...dice].sort((a, b) => a - b)
   const currentEv = cfg.bestAbilityValue(sorted, state)
+  const directMap = cfg.directDamageByName?.(state) ?? null
+
+  const annotateDirect = (opt: KeepOption): KeepOption => {
+    if (!directMap) return opt
+    let max = 0
+    for (const [name, p] of Object.entries(opt.probDist)) {
+      if (p <= 0) continue
+      const d = directMap[name] ?? 0
+      if (d > max) max = d
+    }
+    opt.directDamage = max
+    return opt
+  }
 
   if (rollsRemaining === 0) {
     const dist = _abilityDist(cfg, sorted, 0, state)
     return {
       currentEv,
-      topOptions: [{
+      topOptions: [annotateDirect({
         kept: sorted,
         ev: currentEv,
         probDist: _distToPercent(dist),
-      }],
+      })],
       abilities: cfg.buildAbilityBoard(sorted, state),
     }
   }
@@ -167,7 +184,7 @@ export function calculateOptimalKeep<S>(
 
     const ev = evalState(cfg, kept, rollsRemaining, state)
     const dist = _abilityDist(cfg, kept, rollsRemaining, state)
-    options.push({ kept, ev, probDist: _distToPercent(dist) })
+    options.push(annotateDirect({ kept, ev, probDist: _distToPercent(dist) }))
   }
 
   options.sort((a, b) => b.ev - a.ev)

--- a/engine-ts/src/core/types.ts
+++ b/engine-ts/src/core/types.ts
@@ -15,4 +15,9 @@ export interface CharacterConfig<S> {
   buildAbilityBoard(dice: number[], state: S): AbilityEntry[]
   hasMatchedAbility(dice: number[], state: S): boolean
   stateKey(state: S): string
+  // Map from ability short-name (as in bestAbilityName / probDist) to direct HP damage,
+  // excluding TB / Agility / CP gains. Only the values that actually subtract from enemy
+  // HP this turn. Optional : characters that don't need lethal-without-TB leave undefined
+  // and consumers fall back to baseDamage.
+  directDamageByName?(state: S): Record<string, number>
 }

--- a/static/engine.js
+++ b/static/engine.js
@@ -132,15 +132,27 @@ var Engine = (() => {
   function calculateOptimalKeep(cfg, dice, rollsRemaining, state) {
     const sorted = [...dice].sort((a, b) => a - b);
     const currentEv = cfg.bestAbilityValue(sorted, state);
+    const directMap = cfg.directDamageByName?.(state) ?? null;
+    const annotateDirect = (opt) => {
+      if (!directMap) return opt;
+      let max = 0;
+      for (const [name, p] of Object.entries(opt.probDist)) {
+        if (p <= 0) continue;
+        const d = directMap[name] ?? 0;
+        if (d > max) max = d;
+      }
+      opt.directDamage = max;
+      return opt;
+    };
     if (rollsRemaining === 0) {
       const dist = _abilityDist(cfg, sorted, 0, state);
       return {
         currentEv,
-        topOptions: [{
+        topOptions: [annotateDirect({
           kept: sorted,
           ev: currentEv,
           probDist: _distToPercent(dist)
-        }],
+        })],
         abilities: cfg.buildAbilityBoard(sorted, state)
       };
     }
@@ -157,7 +169,7 @@ var Engine = (() => {
       seenKeys.add(kKey);
       const ev = evalState(cfg, kept, rollsRemaining, state);
       const dist = _abilityDist(cfg, kept, rollsRemaining, state);
-      options.push({ kept, ev, probDist: _distToPercent(dist) });
+      options.push(annotateDirect({ kept, ev, probDist: _distToPercent(dist) }));
     }
     options.sort((a, b) => b.ev - a.ev);
     let topOptions = options.slice(0, 5);
@@ -480,6 +492,23 @@ var Engine = (() => {
     const cands = getCandidates2(dice, upgrades, tbOnOpp);
     return cands.reduce((best, cur) => cur[1] > best[1] ? cur : best)[0];
   }
+  function directDamageByName(upgrades, _tbOnOpp) {
+    const rrt = upgrades >= RRT_THRESHOLD_UPGRADES ? RRT_ALL_ATTACK_BONUS : 0;
+    const hackedThresh = upgrades >= HACKED_THRESHOLD_UPGRADES ? HACKED_THRESHOLD_BONUS : 0;
+    const vengeanceRiderDmg = VENGEANCE_RIDER_DICE * (5 / 6);
+    return {
+      "Baton Strike 3B": BATON_STRIKE_3B + rrt,
+      "Baton Strike 4B": BATON_STRIKE_4B + rrt,
+      "Baton Strike 5B": BATON_STRIKE_5B + rrt,
+      "Infiltrate": INFILTRATE_BASE_DMG + rrt,
+      "Widow's Gauntlets": GAUNTLETS_BASE_DMG + upgrades + rrt,
+      "Hacked": HACKED_BASE_DMG + hackedThresh + rrt,
+      "Grapple": GRAPPLE_BASE_DMG + upgrades + rrt,
+      "Vengeance": VENGEANCE_BASE_DMG + vengeanceRiderDmg + rrt,
+      "Widow's Bite": WIDOWS_BITE_BASE_DMG + rrt,
+      "Whiff": 0
+    };
+  }
   function buildAbilityBoard2(dice, upgrades, tbOnOpp) {
     const matched = new Set(getCandidates2(dice, upgrades, tbOnOpp).map(([n]) => n));
     const rrt = upgrades >= RRT_THRESHOLD_UPGRADES ? RRT_ALL_ATTACK_BONUS : 0;
@@ -525,6 +554,9 @@ var Engine = (() => {
     },
     stateKey(state) {
       return `${state.upgrades}|${state.tbOnOpp}`;
+    },
+    directDamageByName(state) {
+      return directDamageByName(state.upgrades, state.tbOnOpp);
     }
   };
 

--- a/static/index.html
+++ b/static/index.html
@@ -411,15 +411,27 @@ var Engine = (() => {
   function calculateOptimalKeep(cfg, dice, rollsRemaining, state) {
     const sorted = [...dice].sort((a, b) => a - b);
     const currentEv = cfg.bestAbilityValue(sorted, state);
+    const directMap = cfg.directDamageByName?.(state) ?? null;
+    const annotateDirect = (opt) => {
+      if (!directMap) return opt;
+      let max = 0;
+      for (const [name, p] of Object.entries(opt.probDist)) {
+        if (p <= 0) continue;
+        const d = directMap[name] ?? 0;
+        if (d > max) max = d;
+      }
+      opt.directDamage = max;
+      return opt;
+    };
     if (rollsRemaining === 0) {
       const dist = _abilityDist(cfg, sorted, 0, state);
       return {
         currentEv,
-        topOptions: [{
+        topOptions: [annotateDirect({
           kept: sorted,
           ev: currentEv,
           probDist: _distToPercent(dist)
-        }],
+        })],
         abilities: cfg.buildAbilityBoard(sorted, state)
       };
     }
@@ -436,7 +448,7 @@ var Engine = (() => {
       seenKeys.add(kKey);
       const ev = evalState(cfg, kept, rollsRemaining, state);
       const dist = _abilityDist(cfg, kept, rollsRemaining, state);
-      options.push({ kept, ev, probDist: _distToPercent(dist) });
+      options.push(annotateDirect({ kept, ev, probDist: _distToPercent(dist) }));
     }
     options.sort((a, b) => b.ev - a.ev);
     let topOptions = options.slice(0, 5);
@@ -759,6 +771,23 @@ var Engine = (() => {
     const cands = getCandidates2(dice, upgrades, tbOnOpp);
     return cands.reduce((best, cur) => cur[1] > best[1] ? cur : best)[0];
   }
+  function directDamageByName(upgrades, _tbOnOpp) {
+    const rrt = upgrades >= RRT_THRESHOLD_UPGRADES ? RRT_ALL_ATTACK_BONUS : 0;
+    const hackedThresh = upgrades >= HACKED_THRESHOLD_UPGRADES ? HACKED_THRESHOLD_BONUS : 0;
+    const vengeanceRiderDmg = VENGEANCE_RIDER_DICE * (5 / 6);
+    return {
+      "Baton Strike 3B": BATON_STRIKE_3B + rrt,
+      "Baton Strike 4B": BATON_STRIKE_4B + rrt,
+      "Baton Strike 5B": BATON_STRIKE_5B + rrt,
+      "Infiltrate": INFILTRATE_BASE_DMG + rrt,
+      "Widow's Gauntlets": GAUNTLETS_BASE_DMG + upgrades + rrt,
+      "Hacked": HACKED_BASE_DMG + hackedThresh + rrt,
+      "Grapple": GRAPPLE_BASE_DMG + upgrades + rrt,
+      "Vengeance": VENGEANCE_BASE_DMG + vengeanceRiderDmg + rrt,
+      "Widow's Bite": WIDOWS_BITE_BASE_DMG + rrt,
+      "Whiff": 0
+    };
+  }
   function buildAbilityBoard2(dice, upgrades, tbOnOpp) {
     const matched = new Set(getCandidates2(dice, upgrades, tbOnOpp).map(([n]) => n));
     const rrt = upgrades >= RRT_THRESHOLD_UPGRADES ? RRT_ALL_ATTACK_BONUS : 0;
@@ -804,6 +833,9 @@ var Engine = (() => {
     },
     stateKey(state) {
       return `${state.upgrades}|${state.tbOnOpp}`;
+    },
+    directDamageByName(state) {
+      return directDamageByName(state.upgrades, state.tbOnOpp);
     }
   };
 
@@ -1042,7 +1074,11 @@ function bwCallEngine(diceArr, rollsRem, state) {
   }));
   return {
     current_ev: result.currentEv,
-    top_options: result.topOptions.map(o => ({ kept: o.kept, ev: o.ev, prob_dist: o.probDist, is_guaranteed: o.isGuaranteed ?? false })),
+    top_options: result.topOptions.map(o => ({
+      kept: o.kept, ev: o.ev, prob_dist: o.probDist,
+      is_guaranteed: o.isGuaranteed ?? false,
+      direct_damage: o.directDamage ?? 0,
+    })),
     abilities: bwReorderAbilities(abilities),
   };
 }
@@ -1468,19 +1504,10 @@ function renderBWStrategy(data) {
     tightText   = `${label} : ${opts[1].ev.toFixed(2)} EV (écart ${diff})`;
   }
 
-  // ── Lethal detection (simple — #17 raffinera) ─────────────────────
+  // ── Lethal detection (TB/Agility/CP exclus via top.direct_damage) ─
   let lethalCallout = '';
-  if (hpEnemy > 0 && board.length > 0) {
-    const abilityMap     = Object.fromEntries(board.map(a => [a.name, a]));
-    const probKeys       = topOpt?.prob_dist ? Object.keys(topOpt.prob_dist) : [];
-    const maxDmgThisTurn = probKeys.reduce((max, name) => {
-      const ab = abilityMap[name];
-      return ab && ab.base_damage > max ? ab.base_damage : max;
-    }, 0);
-    if (maxDmgThisTurn >= hpEnemy) {
-      const lethalAb = board.find(a => a.base_damage >= hpEnemy && probKeys.includes(a.name));
-      lethalCallout  = `💀 <strong>LETHAL possible</strong> avec ${lethalAb?.name ?? 'une ability'} (${maxDmgThisTurn} dmg / ${hpEnemy} HP)`;
-    }
+  if (hpEnemy > 0 && topOpt && (topOpt.direct_damage ?? 0) >= hpEnemy) {
+    lethalCallout = `💀 <strong>LETHAL possible</strong> ce tour (${topOpt.direct_damage.toFixed(1)} dmg direct / ${hpEnemy} HP)`;
   }
 
   // ── Resources ─────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #17. Base : #19 (#16) → #18 (#15).

## Summary
- `CharacterConfig.directDamageByName?(state)` optional (core/types) : map ability short-name → direct HP dmg (exclut TB/Agility/CP)
- `KeepOption.directDamage` optional (core/evaluator) : max sur probDist, populé seulement si le config expose `directDamageByName`
- BW : helper `directDamageByName` dans abilities.ts, branché dans config.ts. Inclut upg scaling (Gauntlets, Grapple), threshold (Hacked), rider dmg moyen (Vengeance). Exclut TB gain EV, Agility, CP.
- HH : `directDamageByName` absent → `directDamage` undefined → UI HH inchangé (`base_damage` toujours utilisé)
- UI : `bwCallEngine` propage `direct_damage`. `renderBWStrategy` : `isLethal = top.direct_damage >= hpEnemy`
- Rebuild `static/engine.js` inliné dans `static/index.html`

## Acceptance (tests VM bundle)
- `[6,6,6,6,1]` upg=0 HP=5 → Grapple direct=**5** ≥ 5 → **LETHAL** ✓
- `[1,2,3,4,6]` upg=0 HP=7 → Hacked direct=**5** < 7 (EV=7.8 gonflé par TB) → **pas lethal** ✓
- `[1,2,3,4,6]` upg=3 HP=7 → Hacked threshold direct=**7** ≥ 7 → **LETHAL** ✓
- HH `[4,4,4,5,6]` upg=0 → directDamage **undefined** ✓

## Test plan
- [x] `npm test` (33/33)
- [x] Bundle VM test : 3 scénarios acceptance ✓
- [ ] Browser manual BW : enemy HP=5, rouler [6,6,6,6,1] upg=0 → 💀 lethal affiché
- [ ] Browser manual HH : pas de régression